### PR TITLE
Skip case checking for valid SVG attributes

### DIFF
--- a/lib/rules/require-lower-case-attributes.js
+++ b/lib/rules/require-lower-case-attributes.js
@@ -10,7 +10,18 @@
 // div(class='class')
 // ```
 
+var svgAttrs = require('svg-element-attributes');
 var utils = require('../utils');
+
+function isInsideSVG(domPath) {
+  return domPath.some(function (elm) {
+    return elm.tag.toLowerCase() === 'svg';
+  });
+}
+
+function isSVGAttr(tagName, attrName) {
+  return (svgAttrs[tagName] || []).indexOf(attrName) !== -1;
+}
 
 module.exports = function () {};
 
@@ -33,9 +44,28 @@ module.exports.prototype = {
     });
 
     if (!isXml) {
-      file.iterateTokensByType('attribute', function (token) {
-        if (token.name !== token.name.toLowerCase()) {
-          errors.add('All attributes must be written in lower case', token.line, token.col);
+      var domPath = [{ tag: ':root', indent: -1 }];
+
+      file.getTokens().forEach(function (token) {
+        switch (token.type) {
+          case 'tag':
+            while (domPath[domPath.length-1].indent >= token._indent) {
+              domPath.pop();
+            }
+            domPath.push({
+              tag: token.val,
+              indent: token._indent
+            });
+            break;
+          case 'attribute':
+            if (token.name !== token.name.toLowerCase()) {
+              // Skip if recognized as SVG attribute.
+              if (isInsideSVG(domPath) && isSVGAttr(domPath[domPath.length-1].tag, token.name)) {
+                return;
+              }
+              errors.add('All attributes must be written in lower case', token.line, token.col);
+            }
+            break;
         }
       });
     }

--- a/package.json
+++ b/package.json
@@ -93,6 +93,7 @@
     "pug-lexer": "^4.1.0",
     "resolve": "^1.1.7",
     "strip-json-comments": "^2.0.1",
+    "svg-element-attributes": "^1.3.1",
     "void-elements": "^2.0.1"
   },
   "devDependencies": {

--- a/test/fixtures/rules/require-lower-case-attributes-svg.pug
+++ b/test/fixtures/rules/require-lower-case-attributes-svg.pug
@@ -1,0 +1,11 @@
+div
+  svg(
+    viewBox="0 0 124 67"
+  )
+    clipPath(
+      id="path1",
+      clipPathUnits="userSpaceOnUse"
+    )
+      circle(cx="50", cy="50", r="35")
+
+  span(class="element")

--- a/test/rules/require-lower-case-attributes.test.js
+++ b/test/rules/require-lower-case-attributes.test.js
@@ -29,6 +29,12 @@ function createTest(linter, fixturesPath) {
       it('should not report errors found in XML', function () {
         assert.equal(linter.checkString('doctype xml\ndiv(Class=\'class\')').length, 0);
       });
+
+      it('should not report lower case for known SVG attributes', function () {
+        var result = linter.checkFile(fixturesPath + 'require-lower-case-attributes-svg.pug');
+
+        assert.equal(result.length, 0);
+      });
     });
   });
 }


### PR DESCRIPTION
SVG attributes is case sensitive, so `requireLowerCaseAttributes` rule emit errors. PR address this case skipping rule for valid SVG attrs.

Alternatives:

* `//- pug-lint-disable …` comment for element (like eslint). Need more complex code.
* Some config option.